### PR TITLE
pltun-5: migrate pnpm settings to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# pnpm 10+ only reads auth/registry settings from .npmrc; these live here.
+# Mirrored in .npmrc (kebab-case) for backward compat with older pnpm.
+strictDepBuilds: true
+minimumReleaseAge: 1440
+blockExoticSubdeps: true
+
 allowBuilds:
   '@parcel/watcher': false
   sqlite3: true


### PR DESCRIPTION
pnpm 10+ only reads auth/registry settings from .npmrc, so strict-dep-builds, minimum-release-age, block-exotic-subdeps were being silently ignored. Copy them into pnpm-workspace.yaml using camelCase keys. Left in .npmrc for backward compat with older pnpm.